### PR TITLE
Fixed typo in icp_align polling function

### DIFF
--- a/lib/preferences.py
+++ b/lib/preferences.py
@@ -61,6 +61,10 @@ class ObjectAlignmentPreferences(AddonPreferences):
             name="Use Target",
             description="Calc alignment stats at each iteration to assess convergence. SLower per step, may result in less steps",
             default=True)
+    take_m_with = BoolProperty(
+            name="Take m_ Objects with",
+            description="Applies the same Transformation Matrix to all Objects which start with 'm_'",
+            default=False)
     align_methods =['RIGID','ROT_LOC_SCALE']#,'AFFINE']
     align_items = []
     for index, item in enumerate(align_methods):
@@ -104,6 +108,7 @@ class ObjectAlignmentPreferences(AddonPreferences):
         layout.prop(self, "use_target")
         layout.prop(self, "target_d")
         layout.prop(self, "align_meth")
+        layout.prop(self, "take_m_with")
 
         # updater draw function
         addon_updater_ops.update_settings_ui(self,context)

--- a/operators/align_pick_points.py
+++ b/operators/align_pick_points.py
@@ -439,15 +439,10 @@ class OBJECT_OT_align_pick_points(Operator):
         #it's this easy to update the obj...
         self.obj_align.matrix_world = self.obj_align.matrix_world @ new_mat
 
-        print(f"Checking take with, current val {take_m_with}")
         if take_m_with == True:
-            print(f"Take_m_with is True")
             for obj in bpy.context.scene.objects:
                 if obj.name[:2] == "m_":
-                    print(f"Moving object: {obj.name}")
-                    print(f"Matrix to world before: {obj.matrix_world}")
                     obj.matrix_world = obj.matrix_world @ new_mat
-                    print(f"Matrix to world after: {obj.matrix_world}")
                     obj.update_tag()
 
 

--- a/operators/align_pick_points.py
+++ b/operators/align_pick_points.py
@@ -420,6 +420,7 @@ class OBJECT_OT_align_pick_points(Operator):
         #test new method
         settings = get_addon_preferences()
         align_meth = settings.align_meth
+        take_m_with = settings.take_m_with
 
         if align_meth == '0': #rigid transform
             M = affine_matrix_from_points(A, B, shear=False, scale=False, usesvd=True)
@@ -437,6 +438,18 @@ class OBJECT_OT_align_pick_points(Operator):
         #because we calced transform in local space
         #it's this easy to update the obj...
         self.obj_align.matrix_world = self.obj_align.matrix_world @ new_mat
+
+        print(f"Checking take with, current val {take_m_with}")
+        if take_m_with == True:
+            print(f"Take_m_with is True")
+            for obj in bpy.context.scene.objects:
+                if obj.name[:2] == "m_":
+                    print(f"Moving object: {obj.name}")
+                    print(f"Matrix to world before: {obj.matrix_world}")
+                    obj.matrix_world = obj.matrix_world @ new_mat
+                    print(f"Matrix to world after: {obj.matrix_world}")
+                    obj.update_tag()
+
 
         self.obj_align.update_tag()
         context.view_layer.update()

--- a/operators/align_pick_points.py
+++ b/operators/align_pick_points.py
@@ -438,7 +438,7 @@ class OBJECT_OT_align_pick_points(Operator):
         #because we calced transform in local space
         #it's this easy to update the obj...
         self.obj_align.matrix_world = self.obj_align.matrix_world @ new_mat
-
+        print(f"Final Transformation Matrix is: {new_mat}")
         if take_m_with == True:
             for obj in bpy.context.scene.objects:
                 if obj.name[:2] == "m_":

--- a/operators/icp_align.py
+++ b/operators/icp_align.py
@@ -111,15 +111,10 @@ class OBJECT_OT_icp_align(Operator):
 
             align_obj.matrix_world = align_obj.matrix_world @ new_mat
             
-            print(f"Checking take with, current val {take_m_with}")
             if take_m_with == True:
-                print(f"Take_m_with is True")
                 for obj in bpy.context.scene.objects:
                     if obj.name[:2] == "m_":
-                        print(f"Moving object: {obj.name}")
-                        print(f"Matrix to world before: {obj.matrix_world}")
                         obj.matrix_world = obj.matrix_world @ new_mat
-                        print(f"Matrix to world after: {obj.matrix_world}")
                         obj.update_tag()
 
             trans = new_mat.to_translation()

--- a/operators/icp_align.py
+++ b/operators/icp_align.py
@@ -110,7 +110,7 @@ class OBJECT_OT_icp_align(Operator):
                     new_mat[y][z] = M[y][z]
 
             align_obj.matrix_world = align_obj.matrix_world @ new_mat
-            
+            print(f"Final Transformation Matrix is: {new_mat}")
             if take_m_with == True:
                 for obj in bpy.context.scene.objects:
                     if obj.name[:2] == "m_":

--- a/operators/icp_align.py
+++ b/operators/icp_align.py
@@ -41,8 +41,8 @@ class OBJECT_OT_icp_align(Operator):
     @classmethod
     def poll(cls, context):
         condition_1 = len(context.selected_objects) == 2
-        conidion_2 = context.object.type == 'MESH'
-        return condition_1 and condition_1
+        condition_2 = context.object.type == 'MESH'
+        return condition_1 and condition_2
 
     def execute(self, context):
         settings = get_addon_preferences()

--- a/operators/icp_align.py
+++ b/operators/icp_align.py
@@ -85,6 +85,7 @@ class OBJECT_OT_icp_align(Operator):
         iters = settings.icp_iterations
         target_d = settings.target_d
         use_target = settings.use_target
+        take_m_with = settings.take_m_with
         factor = round(1/sample)
 
         n = 0
@@ -109,6 +110,18 @@ class OBJECT_OT_icp_align(Operator):
                     new_mat[y][z] = M[y][z]
 
             align_obj.matrix_world = align_obj.matrix_world @ new_mat
+            
+            print(f"Checking take with, current val {take_m_with}")
+            if take_m_with == True:
+                print(f"Take_m_with is True")
+                for obj in bpy.context.scene.objects:
+                    if obj.name[:2] == "m_":
+                        print(f"Moving object: {obj.name}")
+                        print(f"Matrix to world before: {obj.matrix_world}")
+                        obj.matrix_world = obj.matrix_world @ new_mat
+                        print(f"Matrix to world after: {obj.matrix_world}")
+                        obj.update_tag()
+
             trans = new_mat.to_translation()
             quat = new_mat.to_quaternion()
 

--- a/operators/icp_align_feedback.py
+++ b/operators/icp_align_feedback.py
@@ -193,16 +193,10 @@ class OBJECT_OT_icp_align_feedback(Operator):
                     new_mat[y][z] = M[y][z]
 
             align_obj.matrix_world = align_obj.matrix_world @ new_mat
-            
-            print(f"Checking take with, current val {take_m_with}")
             if take_m_with == True:
-                print(f"Take_m_with is True")
                 for obj in bpy.context.scene.objects:
                     if obj.name[:2] == "m_":
-                        print(f"Moving object: {obj.name}")
-                        print(f"Matrix to world before: {obj.matrix_world}")
                         obj.matrix_world = obj.matrix_world @ new_mat
-                        print(f"Matrix to world after: {obj.matrix_world}")
                         obj.update_tag()
                         
             trans = new_mat.to_translation()

--- a/operators/icp_align_feedback.py
+++ b/operators/icp_align_feedback.py
@@ -263,6 +263,12 @@ class OBJECT_OT_icp_align_feedback(Operator):
                 new_mat[y][z] = M[y][z]
 
         self.align_obj.matrix_world = self.align_obj.matrix_world @ new_mat
+
+        if take_m_with == True:
+                for obj in bpy.context.scene.objects:
+                    if obj.name[:2] == "m_":
+                        obj.matrix_world = obj.matrix_world @ new_mat
+                        obj.update_tag()
         trans = new_mat.to_translation()
         quat = new_mat.to_quaternion()
 

--- a/operators/icp_align_feedback.py
+++ b/operators/icp_align_feedback.py
@@ -90,6 +90,7 @@ class OBJECT_OT_icp_align_feedback(Operator):
         self.iters = settings.icp_iterations
         self.target_d = settings.target_d
         self.use_target = settings.use_target
+        self.take_m_with = settings.take_m_with
         self.sample_factor = round(1/self.sample_fraction)
         self.redraw_frequency = settings.redraw_frequency
 
@@ -167,6 +168,7 @@ class OBJECT_OT_icp_align_feedback(Operator):
         iters = settings.icp_iterations
         target_d = settings.target_d
         use_target = settings.use_target
+        take_m_with = settings.take_m_with
         factor = round(1/sample)
 
         n = 0

--- a/operators/icp_align_feedback.py
+++ b/operators/icp_align_feedback.py
@@ -193,6 +193,18 @@ class OBJECT_OT_icp_align_feedback(Operator):
                     new_mat[y][z] = M[y][z]
 
             align_obj.matrix_world = align_obj.matrix_world @ new_mat
+            
+            print(f"Checking take with, current val {take_m_with}")
+            if take_m_with == True:
+                print(f"Take_m_with is True")
+                for obj in bpy.context.scene.objects:
+                    if obj.name[:2] == "m_":
+                        print(f"Moving object: {obj.name}")
+                        print(f"Matrix to world before: {obj.matrix_world}")
+                        obj.matrix_world = obj.matrix_world @ new_mat
+                        print(f"Matrix to world after: {obj.matrix_world}")
+                        obj.update_tag()
+                        
             trans = new_mat.to_translation()
             quat = new_mat.to_quaternion()
 

--- a/operators/icp_align_feedback.py
+++ b/operators/icp_align_feedback.py
@@ -124,8 +124,8 @@ class OBJECT_OT_icp_align_feedback(Operator):
     @classmethod
     def poll(cls, context):
         condition_1 = len(context.selected_objects) == 2
-        conidion_2 = context.object.type == 'MESH'
-        return condition_1 and condition_1
+        condition_2 = context.object.type == 'MESH'
+        return condition_1 and condition_2
 
     def execute(self, context):
         settings = get_addon_preferences()

--- a/operators/icp_align_feedback.py
+++ b/operators/icp_align_feedback.py
@@ -193,6 +193,7 @@ class OBJECT_OT_icp_align_feedback(Operator):
                     new_mat[y][z] = M[y][z]
 
             align_obj.matrix_world = align_obj.matrix_world @ new_mat
+            print(f"Final Transformation Matrix is: {new_mat}")
             if take_m_with == True:
                 for obj in bpy.context.scene.objects:
                     if obj.name[:2] == "m_":

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -76,6 +76,11 @@ class VIEW3D_PT_object_alignment(Panel):
         row.operator("object.align_exclude_clear", icon="X", text="")
 
         row = layout.row()
+        row.label(text="General Alignment")
+        row = layout.row()
+        row.prop(settings, "take_m_with")
+
+        row = layout.row()
         row.label(text="Initial Alignment")
         row = layout.row()
         row.operator("object.align_picked_points")


### PR DESCRIPTION
The typo led to the polling function not using the second condition (checking if they are meshes e.g.)
Sorry for the confusion, I think this should be a correct pull request.
